### PR TITLE
Sign ledger config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,8 +16,8 @@ cfg.ledgerOwnerId = null;
 // the ledger configuration to use when initializing the ledger
 cfg.config = null;
 
-// the ledger maintainer's ed25519 2020 key.
-cfg.maintainerKeyPath = null;
+// the ledger maintainer's key secret.
+cfg.maintainerKeySecret = null;
 
 // if the node is to be the genesis node, leave this empty, otherwise, specify
 // 'hostname:port' for the genesis node

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,6 +16,9 @@ cfg.ledgerOwnerId = null;
 // the ledger configuration to use when initializing the ledger
 cfg.config = null;
 
+// the ledger maintainer's ed25519 2020 key.
+cfg.maintainerKeyPath = null;
+
 // if the node is to be the genesis node, leave this empty, otherwise, specify
 // 'hostname:port' for the genesis node
 cfg.peers = [];

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -14,6 +14,8 @@ const getAgentIterator = promisify(brLedgerAgent.getAgentIterator);
 const {config, util: {delay, BedrockError}} = bedrock;
 const {WebLedgerClient} = require('web-ledger-client');
 const brHttpsAgent = require('bedrock-https-agent');
+const {Ed25519VerificationKey2020} = require('@digitalbazaar/ed25519-verification-key-2020');
+
 
 // module API
 const api = {};
@@ -80,10 +82,27 @@ async function _findAgent() {
   throw new BedrockError('Ledger agent not found.', 'NotFoundError');
 }
 
+/**
+ * Takes in a path to a maintainerKey.
+ *
+ * @param {string} maintainerKey - A path to a maintainerKey.
+ *
+ * @returns{Promise<Ed25519VerificationKey2020>} - Returns the mainainer's
+ *  Ed25519VerificationKey 2020.
+ */
+async function getMaintainerKey(maintainerKey) {
+  if(!maintainerKey) {
+    return Ed25519VerificationKey2020.generate();
+  }
+  const keyOptions = require(maintainerKey);
+  return new Ed25519VerificationKey2020(keyOptions);
+}
+
 // setup the genesis node
 async function _setupGenesisNode() {
   const ledgerOwner = await _getLedgerOwner();
-  const ledgerConfiguration = cfg.config;
+  const {config: ledgerConfiguration, maintainerKeyPath} = cfg;
+  const maintainerKey = await getMaintainerKey(maintainerKeyPath);
   if(!ledgerConfiguration) {
     throw new BedrockError('Ledger configuration not found. ' +
       '"bedrock.config[\'ledger-core\'].config" not set.', 'NotFoundError');
@@ -95,7 +114,6 @@ async function _setupGenesisNode() {
     public: true,
     owner: ledgerOwner.id,
   }, _agentPlugins(), _storagePlugins());
-
   const brLedgerAgentAdd = promisify(brLedgerAgent.add);
   try {
     await brLedgerAgentAdd(ledgerOwner, null, options);

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -14,8 +14,11 @@ const getAgentIterator = promisify(brLedgerAgent.getAgentIterator);
 const {config, util: {delay, BedrockError}} = bedrock;
 const {WebLedgerClient} = require('web-ledger-client');
 const brHttpsAgent = require('bedrock-https-agent');
-const {Ed25519VerificationKey2020} = require('@digitalbazaar/ed25519-verification-key-2020');
-
+const {purposes: {AssertionProofPurpose}, sign} = require('jsonld-signatures');
+const {Ed25519Signature2020} = require('@digitalbazaar/ed25519-signature-2020');
+const {
+  Ed25519VerificationKey2020
+} = require('@digitalbazaar/ed25519-verification-key-2020');
 
 // module API
 const api = {};
@@ -101,12 +104,15 @@ async function getMaintainerKey(maintainerKey) {
 // setup the genesis node
 async function _setupGenesisNode() {
   const ledgerOwner = await _getLedgerOwner();
-  const {config: ledgerConfiguration, maintainerKeyPath} = cfg;
-  const maintainerKey = await getMaintainerKey(maintainerKeyPath);
-  if(!ledgerConfiguration) {
+  const {config, maintainerKeyPath} = cfg;
+  if(!config) {
     throw new BedrockError('Ledger configuration not found. ' +
       '"bedrock.config[\'ledger-core\'].config" not set.', 'NotFoundError');
   }
+  const key = await getMaintainerKey(maintainerKeyPath);
+  const suite = new Ed25519Signature2020({key});
+  const purpose = new AssertionProofPurpose();
+  const ledgerConfiguration = await sign(config, {suite, purpose});
   // create ledger
   const options = Object.assign({
     ledgerConfiguration,

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -121,6 +121,10 @@ async function _setupGenesisNode() {
     throw e;
   }
 }
+function _getPeerHistoryUrl({peerId, hostname}) {
+  return `https://${hostname}` +
+    `/consensus/continuity2017/peers/${encodeURIComponent(peerId)}`;
+}
 
 // setup a peer node by fetching the genesis block from another peer
 async function _setupPeerNode() {
@@ -172,12 +176,13 @@ async function _setupPeerNode() {
   // Ensure we filter out the local peer from the list of peers
   const localPeerId = await ledgerNode.consensus._localPeers.getPeerId(
     {ledgerNodeId: ledgerNode.id});
-
+  logger.debug({endpoints});
   const peers = endpoints.filter(({targetNode}) => targetNode !== localPeerId)
-    .map(({targetNode}) => {
+    .map(({targetNode, hostname}) => {
       return {
         id: targetNode,
-        url: ledgerNode.consensus._localPeers.getLocalPeerUrl({
+        url: _getPeerHistoryUrl({
+          hostname,
           peerId: targetNode
         })
       };

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -8,6 +8,7 @@ const bedrock = require('bedrock');
 const brAccount = require('bedrock-account');
 const brLedgerAgent = require('bedrock-ledger-agent');
 const brLedgerNode = require('bedrock-ledger-node');
+const {documentLoader} = require('bedrock-jsonld-document-loader');
 const logger = require('./logger');
 const {promisify} = require('util');
 const getAgentIterator = promisify(brLedgerAgent.getAgentIterator);
@@ -112,7 +113,8 @@ async function _setupGenesisNode() {
   const key = await getMaintainerKey(maintainerKeyPath);
   const suite = new Ed25519Signature2020({key});
   const purpose = new AssertionProofPurpose();
-  const ledgerConfiguration = await sign(config, {suite, purpose});
+  const ledgerConfiguration = await sign(
+    config, {suite, purpose, documentLoader});
   // create ledger
   const options = Object.assign({
     ledgerConfiguration,

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -175,7 +175,12 @@ async function _setupPeerNode() {
 
   const peers = endpoints.filter(({targetNode}) => targetNode !== localPeerId)
     .map(({targetNode}) => {
-      return {id: targetNode, url: targetNode};
+      return {
+        id: targetNode,
+        url: ledgerNode.consensus._localPeers.getLocalPeerUrl({
+          peerId: targetNode
+        })
+      };
     });
   logger.debug('Peers', {peers});
   const promises = peers.map(async peer => {

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -3,6 +3,7 @@
  */
 'use strict';
 
+const crypto = require('crypto');
 const _ = require('lodash');
 const bedrock = require('bedrock');
 const brAccount = require('bedrock-account');
@@ -17,9 +18,7 @@ const {WebLedgerClient} = require('web-ledger-client');
 const brHttpsAgent = require('bedrock-https-agent');
 const {purposes: {AssertionProofPurpose}, sign} = require('jsonld-signatures');
 const {Ed25519Signature2020} = require('@digitalbazaar/ed25519-signature-2020');
-const {
-  Ed25519VerificationKey2020
-} = require('@digitalbazaar/ed25519-verification-key-2020');
+const didKeyDriver = require('@digitalbazaar/did-method-key').driver();
 
 // module API
 const api = {};
@@ -86,31 +85,23 @@ async function _findAgent() {
   throw new BedrockError('Ledger agent not found.', 'NotFoundError');
 }
 
-/**
- * Takes in a path to a maintainerKey.
- *
- * @param {string} maintainerKey - A path to a maintainerKey.
- *
- * @returns{Promise<Ed25519VerificationKey2020>} - Returns the mainainer's
- *  Ed25519VerificationKey 2020.
- */
-async function getMaintainerKey(maintainerKey) {
-  if(!maintainerKey) {
-    return Ed25519VerificationKey2020.generate();
-  }
-  const keyOptions = require(maintainerKey);
-  return new Ed25519VerificationKey2020(keyOptions);
-}
-
 // setup the genesis node
 async function _setupGenesisNode() {
   const ledgerOwner = await _getLedgerOwner();
-  const {config, maintainerKeyPath} = cfg;
+  const {config, maintainerKeySecret} = cfg;
   if(!config) {
     throw new BedrockError('Ledger configuration not found. ' +
       '"bedrock.config[\'ledger-core\'].config" not set.', 'NotFoundError');
   }
-  const key = await getMaintainerKey(maintainerKeyPath);
+  let seed = maintainerKeySecret;
+  if(typeof seed === 'string') {
+    // creates 32 byte hashes for passwords
+    const hash32 = crypto.createHash('sha256');
+    hash32.update(maintainerKeySecret);
+    seed = hash32.digest();
+  }
+  const keyPair = await didKeyDriver.generate({seed});
+  const key = keyPair.methodFor({purpose: 'assertionMethod'});
   const suite = new Ed25519Signature2020({key});
   const purpose = new AssertionProofPurpose();
   const ledgerConfiguration = await sign(

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "url": "https://github.com/digitalbazaar/bedrock-ledger-core/issues"
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-ledger-core",
-  "dependencies": {
-    "web-ledger-client": "^3.1.0"
-  },
   "peerDependencies": {
     "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
     "@digitalbazaar/ed25519-verification-key-2020": "^3.1.0",
@@ -34,6 +31,7 @@
     "bedrock-https-agent": "^1.1.0",
     "bedrock-injector": "^1.0.0",
     "bedrock-jobs": "^3.0.0",
+    "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-ledger-agent": "^4.0.0",
     "bedrock-ledger-consensus-continuity": "7.0.0",
     "bedrock-ledger-consensus-continuity-storage": "^3.0.0",
@@ -48,7 +46,8 @@
     "bedrock-rest": "^3.0.0",
     "bedrock-server": "^2.2.1",
     "bedrock-validation": "^4.0.0",
-    "jsonld-signatures": "^9.3.0"
+    "jsonld-signatures": "^9.3.0",
+    "web-ledger-client": "^3.1.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "web-ledger-client": "^3.1.0"
   },
   "peerDependencies": {
+    "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
+    "@digitalbazaar/ed25519-verification-key-2020": "^3.1.0",
     "bedrock": "1.x - 3.x",
     "bedrock-account": "^4.0.0",
     "bedrock-express": "2.x - 3.x",
@@ -45,7 +47,8 @@
     "bedrock-redis": "^3.2.0",
     "bedrock-rest": "^3.0.0",
     "bedrock-server": "^2.2.1",
-    "bedrock-validation": "^4.0.0"
+    "bedrock-validation": "^4.0.0",
+    "jsonld-signatures": "^9.3.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-ledger-core",
   "peerDependencies": {
+    "@digitalbazaar/did-method-key": "^2.0.0",
     "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
-    "@digitalbazaar/ed25519-verification-key-2020": "^3.1.0",
     "bedrock": "1.x - 3.x",
     "bedrock-account": "^4.0.0",
     "bedrock-express": "2.x - 3.x",


### PR DESCRIPTION
1. introduces a new config prop `maintainerKeySecret`
2. Uses the `maintainerKeySecret` to generate a did-key to sign the genesisBlock
3. changes the way peerNodes are added so that a url to the peerNode can fetch that node's history